### PR TITLE
Resolve the local UI backend upstream lazily

### DIFF
--- a/deploy/local/nginx.ui.conf
+++ b/deploy/local/nginx.ui.conf
@@ -4,7 +4,11 @@ server {
     listen 80;
 
     location /api/ {
-        proxy_pass http://backend:9000/api/;
+        # Resolve the backend lazily via Docker's embedded DNS so nginx starts even when the
+        # backend is not up yet (returns 502 until ready instead of failing at config parse).
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $backend backend;
+        proxy_pass http://$backend:9000$request_uri;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
nginx resolved the backend upstream at config-parse time and crash-looped when the backend was not up yet. Resolve it per-request via Docker DNS so the UI starts and returns 502 until the backend is ready.