### PR TITLE
Set explicit cache headers in the fiddle front nginx

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -28,8 +28,17 @@ http {
             proxy_pass http://grafana:3000/;
         }
 
+        # Build artifacts have content-hashed filenames and never change.
+        location /static/ {
+            proxy_pass http://webapp:80;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
         location / {
             proxy_pass http://webapp:80;
+            # index.html references the hashed bundles; without explicit headers CDNs
+            # (Cloudflare) cache it with a multi-day default TTL, hiding new deploys.
+            add_header Cache-Control "no-cache";
         }
 
         location = /robots.txt {


### PR DESCRIPTION
Without origin cache headers Cloudflare cached index.html with a multi-day default TTL, so UI deploys stayed invisible until the edge cache expired or was purged. Serve index.html with no-cache and the content-hashed /static/ bundles as immutable.