### PR TITLE
Publish Docker images to clickhouse/clickhouse-fiddle and clickhouse/clickhouse-fiddle-ui

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -15,35 +15,35 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          username: robotclickhouse
+          password: ${{ secrets.DOCKER_ROBOT_PASSWORD }}
 
       - name: Extract backend image metadata
         id: backend-meta
         uses: docker/metadata-action@v5
         with:
-          images: lodthe/clickhouse-playground
+          images: clickhouse/clickhouse-fiddle
       - name: Build and push backend image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/amd64
-          tags: lodthe/clickhouse-playground:latest,${{ steps.backend-meta.outputs.tags }}
+          tags: clickhouse/clickhouse-fiddle:latest,${{ steps.backend-meta.outputs.tags }}
           labels: ${{ steps.backend-meta.outputs.labels }}
 
       - name: Extract UI image metadata
         id: ui-meta
         uses: docker/metadata-action@v5
         with:
-          images: lodthe/clickhouse-playground-ui
+          images: clickhouse/clickhouse-fiddle-ui
       - name: Build and push UI image
         uses: docker/build-push-action@v6
         with:
           context: ui
           push: true
           platforms: linux/amd64
-          tags: lodthe/clickhouse-playground-ui:latest,${{ steps.ui-meta.outputs.tags }}
+          tags: clickhouse/clickhouse-fiddle-ui:latest,${{ steps.ui-meta.outputs.tags }}
           labels: ${{ steps.ui-meta.outputs.labels }}
           build-args: |
             API_URL=https://fiddle.clickhouse.com/api/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docker-publish-x86
 
 docker-publish-x86:
-	docker buildx build --platform linux/x86_64 -t lodthe/clickhouse-playground .
-	docker push lodthe/clickhouse-playground
+	docker buildx build --platform linux/x86_64 -t clickhouse/clickhouse-fiddle .
+	docker push clickhouse/clickhouse-fiddle
 	@echo "Server image published"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -105,7 +105,7 @@ services:
   playground:
     networks:
       - playground
-    image: lodthe/clickhouse-playground:latest
+    image: clickhouse/clickhouse-fiddle:latest
     environment:
       CONFIG_PATH: /config.yml
     volumes:
@@ -123,7 +123,7 @@ services:
   webapp:
     networks:
       - playground
-    image: lodthe/clickhouse-playground-ui:latest
+    image: clickhouse/clickhouse-fiddle-ui:latest
     restart: unless-stopped
     deploy:
       resources:

--- a/ui/README.md
+++ b/ui/README.md
@@ -26,12 +26,12 @@ Build a Docker image:
 # Address of the backend API
 export API_URL='https://fiddle.clickhouse.com/api/'
 
-docker build --build-arg API_URL="$API_URL" -t lodthe/clickhouse-playground-ui ./ui
+docker build --build-arg API_URL="$API_URL" -t clickhouse/clickhouse-fiddle-ui ./ui
 ```
 
 Run a container based on the built image:
 ```bash
-docker run -d -p 9090:80 lodthe/clickhouse-playground-ui
+docker run -d -p 9090:80 clickhouse/clickhouse-fiddle-ui
 ```
 
 Now the webapp is available on `localhost:9090`.


### PR DESCRIPTION
## Summary
- Replace the `lodthe/clickhouse-playground` and `lodthe/clickhouse-playground-ui` Docker Hub repositories with `clickhouse/clickhouse-fiddle` and `clickhouse/clickhouse-fiddle-ui`
- Log in to Docker Hub as `robotclickhouse` using the `DOCKER_ROBOT_PASSWORD` secret in the image-publish workflow
- Update the deploy `docker-compose.yml`, `Makefile` publish target, and UI README examples to the new image names

Note: the `DOCKER_ROBOT_PASSWORD` secret must be configured in the repository for the publish workflow to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)