### PR TITLE
Copy patches/ before npm ci in the UI Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
+# patches/ must be present before `npm ci`: the postinstall hook runs patch-package
+COPY patches /app/patches
 
 RUN npm ci
 


### PR DESCRIPTION
## Summary
Fixes the UI Docker image build that failed in the publish workflow (https://github.com/ClickHouse/clickhouse-fiddle/actions/runs/32277758542) with:

> Can't import the named export 'useCalendar' (imported as 'useCalendar') from default-exporting module (only default export is available)

`npm ci` runs the `postinstall` hook (`patch-package`), which applies `ui/patches/@h6s+calendar+2.2.0.patch` to fix the broken package exports of `@h6s/calendar` (a click-ui dependency). The Dockerfile only copied `patches/` after `npm ci` (via `COPY . /app`), so the patch was never applied and the production build failed.

## Test plan
- Built the image locally with `docker build --build-arg API_URL="https://fiddle.clickhouse.com/api/" ./ui` — build succeeds
- Ran the resulting container and confirmed the app is served

🤖 Generated with [Claude Code](https://claude.com/claude-code)