### PR TITLE
Fix repository links to point to ClickHouse/clickhouse-fiddle

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -85,6 +85,6 @@ Fiddle has a lot of opportunities for improvement:
 - reducing latency by running containers in advance
 - and many many others...
 
-If you want to suggest new improvements or share any other feedback, please create an issue in the[Github repository](https://github.com/lodthe/clickhouse-playground). It's highly appreciated!
+If you want to suggest new improvements or share any other feedback, please create an issue in the [GitHub repository](https://github.com/ClickHouse/clickhouse-fiddle). It's highly appreciated!
 
 And [fiddle.clickhouse.com](https://fiddle.clickhouse.com) is waiting for your queries :)

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,12 +43,12 @@ for guidelines for other distros.
 At first, you should clone this repository and move to 
 the `deploy` directory:
 ```bash
-git clone git@github.com:lodthe/clickhouse-playground.git
+git clone git@github.com:ClickHouse/clickhouse-fiddle.git
 
 # HTTPS version:
-# git clone https://github.com/lodthe/clickhouse-playground.git
+# git clone https://github.com/ClickHouse/clickhouse-fiddle.git
 
-cd clickhouse-playground/deploy
+cd clickhouse-fiddle/deploy
 ls -lah
 ```
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,7 +23,7 @@ INSERT INTO users VALUES (8888, 'Alice', 50);
 SELECT * FROM users;`;
 
 const apiUrl = process.env.REACT_APP_API_URL;
-const githubRepoUrl = 'https://github.com/lodthe/clickhouse-playground';
+const githubRepoUrl = 'https://github.com/ClickHouse/clickhouse-fiddle';
 
 const localStorageFormatKey = 'clickhouse-playground-format';
 


### PR DESCRIPTION
The "GitHub repository" link in the UI header and the links in the docs still pointed to the old upstream repository (`lodthe/clickhouse-playground`). This updates them to `ClickHouse/clickhouse-fiddle`:

- `ui/src/App.tsx`: `githubRepoUrl` constant used by the UI
- `docs/install.md`: `git clone` commands and the `cd` path
- `docs/about.md`: feedback link (also fixes a missing space and "Github" → "GitHub")

The Go module path (`github.com/lodthe/clickhouse-playground` in `go.mod` and imports) is left as is — renaming the module is a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)