### PR TITLE
Fix box-drawing rendering in the editor and output panes

### DIFF
--- a/ui/src/CodeMirrorTheme.tsx
+++ b/ui/src/CodeMirrorTheme.tsx
@@ -54,7 +54,13 @@ function clickUiEditorTheme(themeName: 'light' | 'dark'): Extension {
       caret: `var(${tokens}-text-default)`,
       gutterBackground: `var(${tokens}-background-default)`,
       gutterForeground: `var(${tokens}-numbers-default)`,
-      fontFamily: 'var(--typography-font-families-mono)',
+      // Not the Click-UI mono stack: its first choice, Inconsolata, is loaded
+      // from Google Fonts as subsets whose unicode-range lacks box drawing
+      // (U+2500..U+259F), so the frames of Pretty* output formats would render
+      // from a metric-incompatible fallback font and misalign. This is the
+      // same stack the ClickHouse Play UI uses; every font in it covers box
+      // drawing.
+      fontFamily: "'DejaVu Sans Mono', 'Liberation Mono', MonoLisa, Consolas, monospace",
       selection: themeName === 'dark' ? '#404859' : '#d5e2f5',
       selectionMatch: themeName === 'dark' ? '#404859' : '#d5e2f5',
       lineHighlight: themeName === 'dark' ? '#31363f' : '#eceef2',
@@ -84,6 +90,13 @@ export const editorChrome = EditorView.theme({
     border: '1px solid var(--click-global-color-stroke-default)',
     'border-radius': 'var(--click-codeblock-radii-all)',
     padding: '3px',
+  },
+  // CodeMirror defaults to line-height 1.4, which leaves gaps between the
+  // vertical lines of box-drawing glyphs on consecutive rows. The fonts above
+  // draw those glyphs to fill exactly their normal line box, so with 'normal'
+  // the frames of Pretty* formats tile seamlessly (as in the Play UI).
+  '.cm-scroller': {
+    lineHeight: 'normal',
   },
   '&.cm-editor.cm-focused': {
     outline: 'none',


### PR DESCRIPTION
## Problem

Since the Click-UI rewrite (#74), the frames of `Pretty*` output formats are misaligned: https://fiddle.clickhouse.com/7ae4e9f7-bd3a-4638-8d98-540c90aa14bd

Two causes:

1. **Font.** The editors used Click-UI's mono stack, `"Inconsolata", Consolas, "SFMono Regular", monospace`. The full Inconsolata font does contain box-drawing glyphs, but the Google Fonts webfont is served as latin/latin-ext/vietnamese subsets whose `unicode-range` does not include U+2500–U+259F. So box-drawing characters fall through to the next font in the stack (`Consolas` is absent on Linux/macOS, and `SFMono Regular` is not a real family name), landing in a generic monospace with different advance widths than Inconsolata — every frame line breaks apart.
2. **Line height.** CodeMirror defaults to `line-height: 1.4`, which leaves vertical gaps between the `│` glyphs of consecutive rows even with a correct font.

## Fix

Use the same font stack as the ClickHouse Play UI — `DejaVu Sans Mono, Liberation Mono, MonoLisa, Consolas, monospace` — every font in it covers box drawing, and set `line-height: normal`, at which these fonts draw box glyphs to fill the line box exactly, so vertical lines touch.

## Before

![before](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/before-crop.png)

## After

![after](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/after-crop.png)

Full-page screenshots: [before](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/before.png), [after](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/after.png).

Verified with `tsc --noEmit` and a production `react-scripts build` on Node 20 (the version used by the UI Dockerfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)