### PR TITLE
Add virtualized hex output viewer

### DIFF
--- a/internal/queryrun/run.go
+++ b/internal/queryrun/run.go
@@ -15,7 +15,10 @@ type Run struct {
 	// BuildType is the ClickHouse build kind (release/debug/asan/...). Empty means release.
 	BuildType string `dynamodbav:"BuildType"`
 	Input     string `dynamodbav:"Input"`
+	// Output remains for API and stored-run compatibility. RawOutput preserves the
+	// exact byte sequence for clients that need to inspect non-UTF-8 output.
 	Output    string `dynamodbav:"Output"`
+	RawOutput []byte `dynamodbav:"RawOutput,omitempty"`
 
 	Database string                  `dynamodbav:"Database"`
 	Settings runsettings.RunSettings `dynamodbav:"Settings"`

--- a/internal/queryrun/run_test.go
+++ b/internal/queryrun/run_test.go
@@ -1,0 +1,20 @@
+package queryrun
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRawOutputIsStoredAsDynamoDBBinary(t *testing.T) {
+	run := &Run{ID: "run-id", RawOutput: []byte{0x00, 0x80, 0xff}}
+
+	item, err := attributevalue.MarshalMap(run)
+
+	require.NoError(t, err)
+	value, ok := item["RawOutput"].(*types.AttributeValueMemberB)
+	require.True(t, ok)
+	require.Equal(t, run.RawOutput, value.Value)
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -191,6 +191,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: include_raw_output
+          in: query
+          description: Include the exact output bytes as Base64 in output_base64.
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: Successful operation
@@ -347,6 +353,9 @@ components:
                 output_format:
                   type: string
                   description: Output format for ClickHouse query results
+        include_raw_output:
+          type: boolean
+          description: Request exact output bytes as Base64 in output_base64.
       required:
         - query
         - version
@@ -364,6 +373,10 @@ components:
             output:
               type: string
               description: Query execution output
+            output_base64:
+              type: string
+              format: byte
+              description: Exact query output bytes, present when include_raw_output is true
             time_elapsed:
               type: string
               description: Time taken to execute the query
@@ -408,6 +421,10 @@ components:
             output:
               type: string
               description: Query execution output
+            output_base64:
+              type: string
+              format: byte
+              description: Exact query output bytes, present when include_raw_output is true
           required:
             - query_run_id
             - version

--- a/pkg/restapi/query_runner.go
+++ b/pkg/restapi/query_runner.go
@@ -1,9 +1,11 @@
 package restapi
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,8 +49,9 @@ func (h *queryHandler) handle(r chi.Router) {
 }
 
 type RunQueryInput struct {
-	Query   string `json:"query"`
-	Version string `json:"version"`
+	Query            string `json:"query"`
+	Version          string `json:"version"`
+	IncludeRawOutput bool   `json:"include_raw_output"`
 	// BuildType is the ClickHouse build kind: "release" (default), "debug", "asan", etc.
 	BuildType string      `json:"build_type"`
 	Database  string      `json:"database"`
@@ -64,9 +67,10 @@ type ClickHouseSettings struct {
 }
 
 type RunQueryOutput struct {
-	QueryRunID  string `json:"query_run_id"`
-	Output      string `json:"output"`
-	TimeElapsed string `json:"time_elapsed"`
+	QueryRunID   string `json:"query_run_id"`
+	Output       string `json:"output"`
+	OutputBase64 string `json:"output_base64,omitempty"`
+	TimeElapsed  string `json:"time_elapsed"`
 }
 
 func convertSettings(req *RunQueryInput) (runsettings.RunSettings, error) {
@@ -163,6 +167,7 @@ func (h *queryHandler) runQuery(w http.ResponseWriter, r *http.Request) {
 
 	timeElapsed := time.Since(startedAt)
 	run.Output = output
+	run.RawOutput = []byte(output)
 	run.ExecutionTime = timeElapsed
 
 	err = h.runRepo.Create(run)
@@ -175,11 +180,15 @@ func (h *queryHandler) runQuery(w http.ResponseWriter, r *http.Request) {
 
 	zlog.Info().Str("id", run.ID).Dur("elapsed", timeElapsed).Msg("saved a new run")
 
-	writeResult(w, RunQueryOutput{
+	result := RunQueryOutput{
 		QueryRunID:  run.ID,
 		Output:      run.Output,
 		TimeElapsed: timeElapsed.Round(time.Millisecond).String(),
-	})
+	}
+	if req.IncludeRawOutput {
+		result.OutputBase64 = encodeOutput(run.RawOutput)
+	}
+	writeResult(w, result)
 }
 
 type GetQueryRunInput struct {
@@ -187,13 +196,33 @@ type GetQueryRunInput struct {
 }
 
 type GetQueryRunOutput struct {
-	QueryRunID string                  `json:"query_run_id"`
-	Database   string                  `json:"database,omitempty"`
-	Version    string                  `json:"version"`
-	BuildType  string                  `json:"build_type,omitempty"`
-	Settings   runsettings.RunSettings `json:"settings,omitempty"`
-	Input      string                  `json:"input"`
-	Output     string                  `json:"output"`
+	QueryRunID   string                  `json:"query_run_id"`
+	Database     string                  `json:"database,omitempty"`
+	Version      string                  `json:"version"`
+	BuildType    string                  `json:"build_type,omitempty"`
+	Settings     runsettings.RunSettings `json:"settings,omitempty"`
+	Input        string                  `json:"input"`
+	Output       string                  `json:"output"`
+	OutputBase64 string                  `json:"output_base64,omitempty"`
+}
+
+func encodeOutput(output []byte) string {
+	return base64.StdEncoding.EncodeToString(output)
+}
+
+func rawOutput(run *queryrun.Run) []byte {
+	if run.RawOutput != nil {
+		return run.RawOutput
+	}
+
+	// Records written before RawOutput was introduced have only the legacy
+	// string field. Its bytes are the best available representation.
+	return []byte(run.Output)
+}
+
+func includeRawOutput(r *http.Request) bool {
+	include, err := strconv.ParseBool(r.URL.Query().Get("include_raw_output"))
+	return err == nil && include
 }
 
 func (h *queryHandler) getQueryRun(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +244,7 @@ func (h *queryHandler) getQueryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResult(w, GetQueryRunOutput{
+	result := GetQueryRunOutput{
 		QueryRunID: run.ID,
 		Database:   run.Database,
 		Version:    run.Version,
@@ -223,5 +252,9 @@ func (h *queryHandler) getQueryRun(w http.ResponseWriter, r *http.Request) {
 		Settings:   run.Settings,
 		Input:      run.Input,
 		Output:     run.Output,
-	})
+	}
+	if includeRawOutput(r) {
+		result.OutputBase64 = encodeOutput(rawOutput(run))
+	}
+	writeResult(w, result)
 }

--- a/pkg/restapi/query_runner_test.go
+++ b/pkg/restapi/query_runner_test.go
@@ -1,0 +1,34 @@
+package restapi
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lodthe/clickhouse-playground/internal/queryrun"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeOutputPreservesNonUTF8Bytes(t *testing.T) {
+	original := []byte{0x00, 0x80, 0xff, 'A'}
+
+	encoded := encodeOutput(original)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+
+	require.NoError(t, err)
+	require.Equal(t, original, decoded)
+}
+
+func TestRawOutputUsesStoredBytesAndFallsBackForLegacyRuns(t *testing.T) {
+	stored := &queryrun.Run{Output: "legacy", RawOutput: []byte{0x80, 0xff}}
+	legacy := &queryrun.Run{Output: "legacy"}
+
+	require.Equal(t, []byte{0x80, 0xff}, rawOutput(stored))
+	require.Equal(t, []byte("legacy"), rawOutput(legacy))
+}
+
+func TestIncludeRawOutput(t *testing.T) {
+	require.True(t, includeRawOutput(httptest.NewRequest("GET", "/runs/id?include_raw_output=true", nil)))
+	require.False(t, includeRawOutput(httptest.NewRequest("GET", "/runs/id?include_raw_output=false", nil)))
+	require.False(t, includeRawOutput(httptest.NewRequest("GET", "/runs/id?include_raw_output=invalid", nil)))
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -46,7 +46,9 @@ type State = {
   buildStatus: string;
   buildElapsedSec: number;
   output: string;
+  rawOutput: Uint8Array | undefined;
   timeElapsed?: string;
+  showHexViewer: boolean;
 };
 
 interface AppProps {
@@ -83,7 +85,9 @@ class App extends React.Component<AppProps, State> {
       buildStatus: '',
       buildElapsedSec: 0,
       output: '',
+      rawOutput: undefined,
       timeElapsed: undefined,
+      showHexViewer: false,
     };
   }
 
@@ -176,6 +180,10 @@ class App extends React.Component<AppProps, State> {
     });
   };
 
+  private handleHexViewerToggle = () => {
+    this.setState((previous) => ({ showHexViewer: !previous.showHexViewer }));
+  };
+
   private handleSelectedVersionChange = (newValue: string) => {
     this.setState({
       selectedVersion: newValue,
@@ -213,6 +221,7 @@ class App extends React.Component<AppProps, State> {
           input: result.input,
           initialInput: result.input,
           output: result.output,
+          rawOutput: result.outputBytes,
           selectedVersion: result.version,
           selectedBuildType: result.buildType,
         });
@@ -222,6 +231,7 @@ class App extends React.Component<AppProps, State> {
         this.setState({
           input: '',
           output: error.message,
+          rawOutput: undefined,
         });
       })
       .finally(() => this.setState({
@@ -244,6 +254,7 @@ class App extends React.Component<AppProps, State> {
           status.logs
           || `Preparing the ${buildType} build for ${version}…\n`
             + 'The first run builds the image from CI artifacts and can take several minutes.',
+        rawOutput: undefined,
       });
     };
 
@@ -260,6 +271,7 @@ class App extends React.Component<AppProps, State> {
       const header = `Failed to build the ${buildType} image for ${version}: ${status.error || 'unknown error'}`;
       this.setState({
         output: status.logs ? `${header}\n\n--- build log ---\n${status.logs}` : header,
+        rawOutput: undefined,
       });
       return false;
     }
@@ -282,6 +294,7 @@ class App extends React.Component<AppProps, State> {
     this.setState({
       requestIsRunning: true,
       output: '',
+      rawOutput: undefined,
       buildStatus: '',
       timeElapsed: undefined,
     });
@@ -293,6 +306,7 @@ class App extends React.Component<AppProps, State> {
           output:
             `Preparing the ${selectedBuildType} build for ${selectedVersion}.\n`
             + 'The first run builds the image from CI artifacts and can take several minutes…',
+          rawOutput: undefined,
         });
 
         this.startBuildTimer();
@@ -302,7 +316,7 @@ class App extends React.Component<AppProps, State> {
         }
 
         // Keep the timer running through container start + query execution.
-        this.setState({ buildStatus: 'Running query', output: '' });
+        this.setState({ buildStatus: 'Running query', output: '', rawOutput: undefined });
       }
 
       const result: RunQueryResponse = await this.client.runQuery(
@@ -314,6 +328,7 @@ class App extends React.Component<AppProps, State> {
 
       this.setState({
         output: result.output,
+        rawOutput: result.outputBytes,
         timeElapsed: result.timeElapsed,
       });
 
@@ -325,6 +340,7 @@ class App extends React.Component<AppProps, State> {
       console.log(error);
       this.setState({
         output: (error as Error).message,
+        rawOutput: undefined,
       });
     } finally {
       this.stopBuildTimer();
@@ -369,19 +385,23 @@ class App extends React.Component<AppProps, State> {
           isFormatSelectionDisabled={formatDisabled}
           githubRepoUrl={githubRepoUrl}
           theme={this.props.theme}
+          showHexViewer={this.state.showHexViewer}
           onVersionChange={this.handleSelectedVersionChange}
           onBuildTypeChange={this.handleSelectedBuildTypeChange}
           onFormatChange={this.handleSelectedFormatChange}
           onRunClick={this.handleRunButtonClick}
           onThemeToggle={this.props.onThemeToggle}
+          onHexViewerToggle={this.handleHexViewerToggle}
         />
         <EditorPanel
           initialInput={this.state.initialInput}
           output={this.state.output}
+          rawOutput={this.state.rawOutput}
           timeElapsed={this.state.timeElapsed}
           requestIsRunning={this.state.requestIsRunning}
           followOutput={this.state.requestIsRunning && this.state.buildStatus !== ''}
           theme={this.props.theme}
+          showHexViewer={this.state.showHexViewer}
           onInputChange={this.handleInputChange}
         />
       </div>

--- a/ui/src/api/PlaygroundAPI.tsx
+++ b/ui/src/api/PlaygroundAPI.tsx
@@ -21,16 +21,41 @@ export type GetQueryRunResponse = {
   buildType: string;
   input: string;
   output: string;
+  outputBytes: Uint8Array;
   queryRunId: string;
 };
 
 export type RunQueryResponse = {
   queryRunId: string;
   output: string;
+  outputBytes: Uint8Array;
   timeElapsed: string;
 };
 
 export const RELEASE_BUILD_TYPE = 'release';
+
+function textToBytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+// Older API deployments do not recognize include_raw_output. They return the
+// legacy text field, which is still a useful UTF-8 fallback for the hex view.
+function decodeOutputBytes(output: string, outputBase64: unknown): Uint8Array {
+  if (typeof outputBase64 !== 'string') {
+    return textToBytes(output);
+  }
+
+  try {
+    const binary = window.atob(outputBase64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return textToBytes(output);
+  }
+}
 
 export class Client {
   apiBaseUrl: string;
@@ -146,6 +171,7 @@ export class Client {
         query,
         version,
         build_type: buildType,
+        include_raw_output: true,
         settings: {
           clickhouse: {
             output_format: format,
@@ -161,6 +187,7 @@ export class Client {
           return {
             queryRunId: response.result.query_run_id,
             output: response.result.output,
+            outputBytes: decodeOutputBytes(response.result.output, response.result.output_base64),
             timeElapsed: response.result.time_elapsed,
           };
         }
@@ -172,7 +199,7 @@ export class Client {
   }
 
   public getQueryRun(id: string): Promise<GetQueryRunResponse> {
-    return fetch(`${this.apiBaseUrl}runs/${id}`)
+    return fetch(`${this.apiBaseUrl}runs/${id}?include_raw_output=true`)
       .then((response) => response.json())
       .then((response) => {
         if (response.result) {
@@ -181,6 +208,7 @@ export class Client {
             buildType: response.result.build_type || RELEASE_BUILD_TYPE,
             input: response.result.input,
             output: response.result.output,
+            outputBytes: decodeOutputBytes(response.result.output, response.result.output_base64),
             queryRunId: response.result.query_run_id,
           };
         }

--- a/ui/src/components/EditorPanel.tsx
+++ b/ui/src/components/EditorPanel.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { sql } from '@codemirror/lang-sql';
-import { EditorView, keymap } from '@codemirror/view';
-import { Prec } from '@codemirror/state';
+import { Decoration, EditorView, keymap } from '@codemirror/view';
+import { Extension, Prec } from '@codemirror/state';
 import { autocompletion } from '@codemirror/autocomplete';
 import { ThemeName } from '@clickhouse/click-ui';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { editorChrome, editorTheme } from '../CodeMirrorTheme';
 import clickhouseSqlHighlight from '../sql/highlight';
+import HexViewer, { OutputRange } from './HexViewer';
 
 // CodeMirror's default keymap binds Mod-Enter (Cmd-Enter on macOS, Ctrl-Enter
 // elsewhere) to "insert blank line". Consume it here so the shortcut only
@@ -35,9 +36,11 @@ function useIsMobile(): boolean {
 interface EditorPanelProps {
   initialInput: string;
   output: string;
+  rawOutput: Uint8Array | undefined;
   timeElapsed: string | undefined;
   requestIsRunning: boolean;
   followOutput: boolean;
+  showHexViewer: boolean;
   theme: ThemeName;
   onInputChange: (value: string) => void;
 }
@@ -45,13 +48,16 @@ interface EditorPanelProps {
 function EditorPanel({
   initialInput,
   output,
+  rawOutput,
   timeElapsed,
   requestIsRunning,
   followOutput,
+  showHexViewer,
   theme,
   onInputChange,
 }: EditorPanelProps) {
   const isMobile = useIsMobile();
+  const [highlightedOutputRanges, setHighlightedOutputRanges] = useState<OutputRange[]>([]);
 
   const panelDirection = isMobile ? 'vertical' : 'horizontal';
   const codeMirrorTheme = editorTheme(theme);
@@ -67,6 +73,37 @@ function EditorPanel({
       view.scrollDOM.scrollTop = view.scrollDOM.scrollHeight;
     }
   }, [output, followOutput]);
+
+  // Each range marks the full source character for a hovered or pinned UTF-8
+  // sequence. Sort the decorations because CodeMirror requires document order.
+  const outputHighlight = React.useMemo<Extension>(() => {
+    if (highlightedOutputRanges.length === 0) {
+      return [];
+    }
+
+    const sortedRanges = highlightedOutputRanges
+      .filter((range, index, ranges) => ranges.findIndex(
+        (candidate) => candidate.from === range.from && candidate.to === range.to,
+      ) === index)
+      .sort((left, right) => left.from - right.from || left.to - right.to);
+    const mergedRanges: OutputRange[] = [];
+    sortedRanges.forEach((range) => {
+      const previous = mergedRanges[mergedRanges.length - 1];
+      if (previous && range.from <= previous.to) {
+        previous.to = Math.max(previous.to, range.to);
+      } else {
+        mergedRanges.push({ ...range });
+      }
+    });
+
+    return EditorView.decorations.of(Decoration.set(mergedRanges.map((range) => (
+      Decoration.mark({ class: 'output-hex-highlight' }).range(range.from, range.to)
+    ))));
+  }, [highlightedOutputRanges]);
+
+  useEffect(() => {
+    setHighlightedOutputRanges([]);
+  }, [output, showHexViewer]);
 
   const panelStyle: React.CSSProperties = {
     overflow: 'hidden',
@@ -86,6 +123,27 @@ function EditorPanel({
     display: 'flex',
     flexDirection: 'column',
   };
+
+  const outputEditor = (
+    <CodeMirror
+      ref={outputRef}
+      theme={codeMirrorTheme}
+      value={output}
+      basicSetup={{
+        lineNumbers: false,
+        foldGutter: false,
+        dropCursor: true,
+        indentOnInput: false,
+        highlightActiveLine: false,
+      }}
+      style={codeMirrorStyle}
+      className="cm-editor-container"
+      extensions={[editorChrome, EditorView.lineWrapping, outputHighlight]}
+      readOnly
+    />
+  );
+
+  const outputPaneStyle: React.CSSProperties = { ...panelStyle, position: 'relative' };
 
   return (
     <div className="editor-area">
@@ -133,24 +191,28 @@ function EditorPanel({
           />
         </Panel>
         <PanelResizeHandle className={isMobile ? 'resize-handle-vertical' : 'resize-handle-horizontal'} />
-        <Panel defaultSize={isMobile ? 60 : 50} minSize={20} style={{ ...panelStyle, position: 'relative' }}>
-          <CodeMirror
-            ref={outputRef}
-            theme={codeMirrorTheme}
-            value={output}
-            basicSetup={{
-              lineNumbers: false,
-              foldGutter: false,
-              dropCursor: true,
-              indentOnInput: false,
-              highlightActiveLine: false,
-            }}
-            style={codeMirrorStyle}
-            className="cm-editor-container"
-            extensions={[editorChrome, EditorView.lineWrapping]}
-            readOnly
-          />
-          {timeElapsed && <div className="time-elapsed">{timeElapsed}</div>}
+        <Panel defaultSize={isMobile ? 60 : 50} minSize={20} style={panelStyle}>
+          {showHexViewer ? (
+            <PanelGroup direction="vertical" style={{ height: '100%', minHeight: 0 }}>
+              <Panel defaultSize={65} minSize={20} style={outputPaneStyle}>
+                {outputEditor}
+                {timeElapsed && <div className="time-elapsed">{timeElapsed}</div>}
+              </Panel>
+              <PanelResizeHandle className="resize-handle-vertical" />
+              <Panel defaultSize={35} minSize={15} style={panelStyle}>
+                <HexViewer
+                  output={output}
+                  rawOutput={rawOutput}
+                  onHighlightRanges={setHighlightedOutputRanges}
+                />
+              </Panel>
+            </PanelGroup>
+          ) : (
+            <div style={outputPaneStyle}>
+              {outputEditor}
+              {timeElapsed && <div className="time-elapsed">{timeElapsed}</div>}
+            </div>
+          )}
         </Panel>
       </PanelGroup>
     </div>

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -26,11 +26,13 @@ interface HeaderProps {
   isFormatSelectionDisabled: boolean;
   githubRepoUrl: string;
   theme: ThemeName;
+  showHexViewer: boolean;
   onVersionChange: (newValue: string) => void;
   onBuildTypeChange: (newValue: string) => void;
   onFormatChange: (newValue: string) => void;
   onRunClick: (event: React.FormEvent) => void;
   onThemeToggle: () => void;
+  onHexViewerToggle: () => void;
 }
 
 function Header({
@@ -46,11 +48,13 @@ function Header({
   isFormatSelectionDisabled,
   githubRepoUrl,
   theme,
+  showHexViewer,
   onVersionChange,
   onBuildTypeChange,
   onFormatChange,
   onRunClick,
   onThemeToggle,
+  onHexViewerToggle,
 }: HeaderProps) {
   return (
     <header className="app-header">
@@ -104,6 +108,13 @@ function Header({
       <div className="app-header-spacer" />
 
       <div className="app-header-actions">
+        <IconButton
+          type={showHexViewer ? 'primary' : 'ghost'}
+          icon="code"
+          aria-pressed={showHexViewer}
+          title={showHexViewer ? 'Hide hexadecimal output' : 'Show hexadecimal output'}
+          onClick={onHexViewerToggle}
+        />
         <IconButton
           type="ghost"
           icon={theme === 'light' ? 'moon' : 'light-bulb-on'}

--- a/ui/src/components/HexViewer.tsx
+++ b/ui/src/components/HexViewer.tsx
@@ -1,0 +1,321 @@
+import * as React from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+const bytesPerRow = 16;
+const rowHeight = 24;
+const overscanRows = 5;
+
+export type OutputRange = {
+  from: number;
+  to: number;
+};
+
+type ByteSelection = {
+  byteFrom: number;
+  byteTo: number;
+  outputRange?: OutputRange;
+};
+
+interface HexViewerProps {
+  output: string;
+  rawOutput: Uint8Array | undefined;
+  onHighlightRanges: (ranges: OutputRange[]) => void;
+}
+
+function byteToAscii(value: number): string {
+  return value >= 0x20 && value <= 0x7e ? String.fromCharCode(value) : '.';
+}
+
+function isContinuationByte(value: number): boolean {
+  return value >= 0x80 && value <= 0xbf;
+}
+
+// Return the complete UTF-8 code point length at offset, or zero for an
+// invalid byte. Invalid bytes have no stable position in the JSON text field.
+function utf8CodePointLength(bytes: Uint8Array, offset: number): number {
+  const first = bytes[offset];
+  const second = bytes[offset + 1];
+  const third = bytes[offset + 2];
+  const fourth = bytes[offset + 3];
+
+  if (first <= 0x7f) {
+    return 1;
+  }
+  if (first >= 0xc2 && first <= 0xdf && isContinuationByte(second)) {
+    return 2;
+  }
+  if (first === 0xe0 && second >= 0xa0 && second <= 0xbf && isContinuationByte(third)) {
+    return 3;
+  }
+  if (
+    ((first >= 0xe1 && first <= 0xec) || (first >= 0xee && first <= 0xef))
+    && isContinuationByte(second)
+    && isContinuationByte(third)
+  ) {
+    return 3;
+  }
+  if (first === 0xed && second >= 0x80 && second <= 0x9f && isContinuationByte(third)) {
+    return 3;
+  }
+  if (
+    first === 0xf0
+    && second >= 0x90
+    && second <= 0xbf
+    && isContinuationByte(third)
+    && isContinuationByte(fourth)
+  ) {
+    return 4;
+  }
+  if (
+    first >= 0xf1
+    && first <= 0xf3
+    && isContinuationByte(second)
+    && isContinuationByte(third)
+    && isContinuationByte(fourth)
+  ) {
+    return 4;
+  }
+  if (
+    first === 0xf4
+    && second >= 0x80
+    && second <= 0x8f
+    && isContinuationByte(third)
+    && isContinuationByte(fourth)
+  ) {
+    return 4;
+  }
+
+  return 0;
+}
+
+function bytesMatch(bytes: Uint8Array, offset: number, encoded: Uint8Array): boolean {
+  if (offset + encoded.length > bytes.length) return false;
+  for (let index = 0; index < encoded.length; index += 1) {
+    if (bytes[offset + index] !== encoded[index]) return false;
+  }
+  return true;
+}
+
+// CodeMirror uses UTF-16 offsets. Valid UTF-8 code points map directly to the
+// rendered text. Bytes that JSON replaced with U+FFFD deliberately have no
+// output range, so hovering them never highlights the wrong output character.
+function byteSelections(output: string, bytes: Uint8Array): ByteSelection[] {
+  const selections: ByteSelection[] = new Array(bytes.length);
+  const encoder = new TextEncoder();
+  let byteOffset = 0;
+  let outputOffset = 0;
+
+  while (byteOffset < bytes.length) {
+    const length = utf8CodePointLength(bytes, byteOffset);
+    if (length === 0) {
+      selections[byteOffset] = { byteFrom: byteOffset, byteTo: byteOffset + 1 };
+      byteOffset += 1;
+      if (output.codePointAt(outputOffset) === 0xfffd) outputOffset += 1;
+    } else {
+      const selection: ByteSelection = {
+        byteFrom: byteOffset,
+        byteTo: byteOffset + length,
+      };
+      const codePoint = output.codePointAt(outputOffset);
+      const outputEnd = outputOffset + (codePoint !== undefined && codePoint > 0xffff ? 2 : 1);
+      const encoded = encoder.encode(output.slice(outputOffset, outputEnd));
+      if (encoded.length === length && bytesMatch(bytes, byteOffset, encoded)) {
+        selection.outputRange = { from: outputOffset, to: outputEnd };
+        outputOffset = outputEnd;
+      }
+
+      for (let index = 0; index < length; index += 1) {
+        selections[byteOffset + index] = selection;
+      }
+
+      byteOffset += length;
+    }
+  }
+
+  return selections;
+}
+
+function HexViewer({ output, rawOutput, onHighlightRanges }: HexViewerProps) {
+  const bytes = useMemo(() => rawOutput || new TextEncoder().encode(output), [output, rawOutput]);
+  const selections = useMemo(() => byteSelections(output, bytes), [output, bytes]);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [hoveredSelection, setHoveredSelection] = useState<ByteSelection>();
+  const [pinnedSelections, setPinnedSelections] = useState<ByteSelection[]>([]);
+  const rowCount = Math.ceil(bytes.length / bytesPerRow);
+
+  const publishHighlights = (pinned: ByteSelection[], hovered?: ByteSelection) => {
+    const outputRanges = [...pinned, ...(hovered ? [hovered] : [])]
+      .flatMap((selection) => (selection.outputRange ? [selection.outputRange] : []));
+    onHighlightRanges(outputRanges);
+  };
+
+  const previewSelection = (selection: ByteSelection | undefined) => {
+    setHoveredSelection(selection);
+    publishHighlights(pinnedSelections, selection);
+  };
+
+  const togglePinnedSelection = (selection: ByteSelection) => {
+    const isAlreadyPinned = pinnedSelections.some((pinned) => (
+      pinned.byteFrom === selection.byteFrom && pinned.byteTo === selection.byteTo
+    ));
+    const nextSelections = isAlreadyPinned
+      ? pinnedSelections.filter((pinned) => (
+        pinned.byteFrom !== selection.byteFrom || pinned.byteTo !== selection.byteTo
+      ))
+      : [...pinnedSelections, selection];
+    setPinnedSelections(nextSelections);
+    setHoveredSelection(undefined);
+    publishHighlights(nextSelections);
+  };
+
+  const clearPinnedSelections = () => {
+    setPinnedSelections([]);
+    setHoveredSelection(undefined);
+    onHighlightRanges([]);
+  };
+
+  useLayoutEffect(() => {
+    const element = contentRef.current;
+    if (!element) return undefined;
+
+    const updateViewport = () => setViewportHeight(element.clientHeight);
+    updateViewport();
+    const observer = new ResizeObserver(updateViewport);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = contentRef.current;
+    if (element) {
+      element.scrollTop = 0;
+    }
+    setScrollTop(0);
+  }, [bytes]);
+
+  useEffect(() => {
+    clearPinnedSelections();
+  }, [bytes]);
+
+  const isHoveredByte = (offset: number) => hoveredSelection !== undefined
+    && offset >= hoveredSelection.byteFrom
+    && offset < hoveredSelection.byteTo;
+  const isPinnedByte = (offset: number) => pinnedSelections.some((selection) => (
+    offset >= selection.byteFrom && offset < selection.byteTo
+  ));
+  const isPinnedSegmentStart = (offset: number) => isPinnedByte(offset)
+    && (offset % bytesPerRow === 0 || !isPinnedByte(offset - 1));
+  const isPinnedSegmentEnd = (offset: number) => isPinnedByte(offset)
+    && (
+      (offset + 1) % bytesPerRow === 0
+      || offset + 1 === bytes.length
+      || !isPinnedByte(offset + 1)
+    );
+
+  const selectionClassNames = (baseClass: string, offset: number) => [
+    baseClass,
+    isHoveredByte(offset) ? `${baseClass}-active` : '',
+    isPinnedByte(offset) ? `${baseClass}-pinned` : '',
+    isPinnedSegmentStart(offset) ? `${baseClass}-pinned-start` : '',
+    isPinnedSegmentEnd(offset) ? `${baseClass}-pinned-end` : '',
+  ].filter(Boolean).join(' ');
+
+  const firstRow = Math.max(0, Math.floor(scrollTop / rowHeight) - overscanRows);
+  const lastRow = Math.min(
+    rowCount,
+    Math.ceil((scrollTop + viewportHeight) / rowHeight) + overscanRows,
+  );
+  const visibleRows: number[] = [];
+  for (let row = firstRow; row < lastRow; row += 1) visibleRows.push(row);
+
+  return (
+    <div
+      className="hex-viewer"
+      onMouseLeave={() => previewSelection(undefined)}
+    >
+      <div className="hex-viewer-title">
+        <span>Hex output</span>
+        <span className="hex-viewer-hint">Hover to preview · click to pin · Esc to clear</span>
+      </div>
+      <div
+        ref={contentRef}
+        className="hex-viewer-content"
+        role="grid"
+        tabIndex={0}
+        aria-label="Output hexadecimal bytes"
+        aria-rowcount={rowCount}
+        onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') clearPinnedSelections();
+        }}
+      >
+        {rowCount === 0 && <div className="hex-viewer-empty">No output bytes</div>}
+        {rowCount > 0 && (
+          <div className="hex-viewer-virtual-space" style={{ height: rowCount * rowHeight }}>
+            {visibleRows.map((rowIndex) => {
+              const offset = rowIndex * bytesPerRow;
+              const rowBytes = bytes.subarray(offset, Math.min(offset + bytesPerRow, bytes.length));
+              return (
+                <div className="hex-viewer-row" role="row" key={offset} style={{ top: rowIndex * rowHeight }}>
+                  <span className="hex-viewer-offset">{offset.toString(16).padStart(8, '0')}</span>
+                  <span className="hex-viewer-bytes">
+                    {Array.from(rowBytes, (value, index) => {
+                      const byteOffset = offset + index;
+                      const selection = selections[byteOffset];
+                      return (
+                        <button
+                          className={selectionClassNames('hex-viewer-byte', byteOffset)}
+                          type="button"
+                          key={byteOffset}
+                          onMouseEnter={() => previewSelection(selection)}
+                          onFocus={() => previewSelection(selection)}
+                          onBlur={() => previewSelection(undefined)}
+                          onClick={() => togglePinnedSelection(selection)}
+                          aria-label={`Byte ${byteOffset}: ${value.toString(16).padStart(2, '0')}`}
+                          aria-pressed={isPinnedByte(byteOffset)}
+                        >
+                          {value.toString(16).padStart(2, '0')}
+                        </button>
+                      );
+                    })}
+                  </span>
+                  <span className="hex-viewer-ascii">
+                    {Array.from(rowBytes, (value, index) => {
+                      const byteOffset = offset + index;
+                      const selection = selections[byteOffset];
+                      return (
+                        <button
+                          className={selectionClassNames('hex-viewer-ascii-byte', byteOffset)}
+                          type="button"
+                          key={byteOffset}
+                          onMouseEnter={() => previewSelection(selection)}
+                          onFocus={() => previewSelection(selection)}
+                          onBlur={() => previewSelection(undefined)}
+                          onClick={() => togglePinnedSelection(selection)}
+                          aria-label={`ASCII byte ${byteOffset}: ${byteToAscii(value)}`}
+                          aria-pressed={isPinnedByte(byteOffset)}
+                        >
+                          {byteToAscii(value)}
+                        </button>
+                      );
+                    })}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default HexViewer;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -5,6 +5,19 @@ body,
   margin: 0;
 }
 
+:root,
+[data-cui-theme='light'] {
+  --hex-selection-background: #d5e2f5;
+  --hex-selection-pinned-background: #c4d9f7;
+  --hex-selection-border: #7796c5;
+}
+
+[data-cui-theme='dark'] {
+  --hex-selection-background: #404859;
+  --hex-selection-pinned-background: #4e5a70;
+  --hex-selection-border: #8190ac;
+}
+
 .app-root {
   display: flex;
   flex-direction: column;
@@ -125,6 +138,189 @@ body,
   color: var(--click-global-color-text-muted);
   box-shadow: 0 0 2px var(--click-global-color-shadow-default);
   z-index: 10;
+}
+
+.hex-viewer {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--click-global-color-stroke-default);
+  border-radius: 6px;
+  background: var(--click-global-color-background-default);
+  color: var(--click-global-color-text-default);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.hex-viewer-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--click-global-color-stroke-default);
+  background: var(--click-global-color-background-muted);
+  color: var(--click-global-color-text-default);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 7px 10px;
+}
+
+.hex-viewer-hint {
+  color: var(--click-global-color-text-muted);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: normal;
+}
+
+.hex-viewer-content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 6px;
+}
+
+.hex-viewer-virtual-space {
+  position: relative;
+  min-width: 76ch;
+}
+
+.hex-viewer-row {
+  display: grid;
+  grid-template-columns: 9ch 48ch auto;
+  align-items: center;
+  gap: 10px;
+  min-width: max-content;
+  border-radius: 3px;
+  line-height: 24px;
+  padding: 0 4px;
+  position: absolute;
+  left: 0;
+}
+
+.hex-viewer-row:hover {
+  background: var(--click-global-color-background-muted);
+}
+
+.hex-viewer-offset,
+.hex-viewer-ascii {
+  color: var(--click-global-color-text-muted);
+}
+
+.hex-viewer-ascii {
+  display: inline-flex;
+}
+
+.hex-viewer-bytes {
+  display: inline-flex;
+}
+
+.hex-viewer-byte {
+  width: calc(2ch + 2px);
+  height: 20px;
+  box-sizing: border-box;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  color: inherit;
+  cursor: crosshair;
+  font: inherit;
+  line-height: 18px;
+  padding: 0;
+}
+
+.hex-viewer-byte:hover,
+.hex-viewer-byte:focus-visible,
+.hex-viewer-byte-active {
+  background: var(--hex-selection-background);
+  outline: 1px solid var(--hex-selection-border);
+  outline-offset: 0;
+}
+
+.hex-viewer-byte-pinned {
+  background: var(--hex-selection-pinned-background);
+  border-top: 1px solid var(--hex-selection-border);
+  border-bottom: 1px solid var(--hex-selection-border);
+  border-radius: 0;
+  outline: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.hex-viewer-byte-pinned-start {
+  border-left: 1px solid var(--hex-selection-border);
+  border-radius: 3px 0 0 3px;
+}
+
+.hex-viewer-byte-pinned-end {
+  border-right: 1px solid var(--hex-selection-border);
+  border-radius: 0 3px 3px 0;
+}
+
+.hex-viewer-byte-pinned-start.hex-viewer-byte-pinned-end {
+  border-radius: 3px;
+}
+
+.hex-viewer-ascii-byte {
+  width: 1ch;
+  height: 20px;
+  box-sizing: border-box;
+  border: 0;
+  border-radius: 1px;
+  background: transparent;
+  color: inherit;
+  cursor: crosshair;
+  font: inherit;
+  line-height: 18px;
+  padding: 0;
+}
+
+.hex-viewer-ascii-byte:hover,
+.hex-viewer-ascii-byte:focus-visible,
+.hex-viewer-ascii-byte-active {
+  background: var(--hex-selection-background);
+  color: var(--click-global-color-text-default);
+  outline: 1px solid var(--hex-selection-border);
+}
+
+.hex-viewer-ascii-byte-pinned {
+  background: var(--hex-selection-pinned-background);
+  border-top: 1px solid var(--hex-selection-border);
+  border-bottom: 1px solid var(--hex-selection-border);
+  border-radius: 0;
+  color: var(--click-global-color-text-default);
+  outline: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.hex-viewer-ascii-byte-pinned-start {
+  border-left: 1px solid var(--hex-selection-border);
+  border-radius: 3px 0 0 3px;
+}
+
+.hex-viewer-ascii-byte-pinned-end {
+  border-right: 1px solid var(--hex-selection-border);
+  border-radius: 0 3px 3px 0;
+}
+
+.hex-viewer-ascii-byte-pinned-start.hex-viewer-ascii-byte-pinned-end {
+  border-radius: 3px;
+}
+
+.hex-viewer-empty {
+  color: var(--click-global-color-text-muted);
+  padding-top: 4px;
+}
+
+.output-hex-highlight {
+  border-radius: 2px;
+  background: var(--hex-selection-background) !important;
+  box-shadow: 0 0 0 1px var(--hex-selection-border);
+  outline: 0;
 }
 
 .cm-editor-container .cm-editor {


### PR DESCRIPTION
Adds an optional, resizable hex viewer below query output. It displays exact output bytes with offsets and ASCII, preserves binary and invalid UTF-8 data through Base64 transport and DynamoDB binary storage, and remains compatible with older clients and saved runs. Rows are virtualized for large outputs. Hovering maps complete UTF-8 sequences to the text output, while clicking pins multiple selections across the hex and ASCII columns.