### PR TITLE
Fix max query length configuration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -109,18 +109,7 @@ func main() {
 	// Initialize the REST server.
 	runRepo := queryrun.NewRepository(ctx, dynamodbClient, config.AWS.QueryRunsTableName)
 
-	lim := config.Limits
-	router := api.NewRouter(api.RouterOpts{
-		Logger:          logger,
-		Runner:          coord,
-		Preparer:        coord,
-		TagStorage:      tagStorage,
-		RunRepo:         runRepo,
-		Timeout:         config.API.ServerTimeout,
-		CacheDisabled:   config.API.CacheDisabled,
-		MaxQueryLength:  lim.MaxOutputLength,
-		MaxOutputLength: lim.MaxOutputLength,
-	})
+	router := api.NewRouter(newRouterOpts(config, logger, coord, coord, tagStorage, runRepo))
 
 	srv := &http.Server{
 		Addr:              config.API.ListeningAddress,
@@ -170,6 +159,29 @@ func main() {
 	err = srv.Shutdown(shutdownCtx)
 	if err != nil {
 		zlog.Error().Err(err).Msg("server shutdown failed")
+	}
+}
+
+func newRouterOpts(
+	config *Config,
+	logger zerolog.Logger,
+	runner api.QueryRunner,
+	preparer api.ImagePreparer,
+	tagStorage api.TagStorage,
+	runRepo queryrun.Repository,
+) api.RouterOpts {
+	lim := config.Limits
+
+	return api.RouterOpts{
+		Logger:          logger,
+		Runner:          runner,
+		Preparer:        preparer,
+		TagStorage:      tagStorage,
+		RunRepo:         runRepo,
+		Timeout:         config.API.ServerTimeout,
+		CacheDisabled:   config.API.CacheDisabled,
+		MaxQueryLength:  lim.MaxQueryLength,
+		MaxOutputLength: lim.MaxOutputLength,
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRouterOptsUsesIndependentLimits(t *testing.T) {
+	opts := newRouterOpts(
+		&Config{
+			Limits: Limits{
+				MaxQueryLength:  3,
+				MaxOutputLength: 5,
+			},
+		},
+		zerolog.Nop(),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	require.Equal(t, uint64(3), opts.MaxQueryLength)
+	require.Equal(t, uint64(5), opts.MaxOutputLength)
+}


### PR DESCRIPTION
## What changed

- Fixed a config wiring typo in the API server.
- MaxQueryLength now uses limits.max_query_length.
- MaxOutputLength still uses limits.max_output_length.
- Added a regression test with different values for both limits.

## Why

The old code used the output limit for both settings. With the default config, a query could be 25,000 bytes even though max_query_length is 2,500.

## Testing

- go test ./...
- go vet ./...